### PR TITLE
Change strptime format for 3-letter month

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,7 +45,7 @@ my $build = Module::Build->new
    requires => {
                 'Scalar::Util' => 1.13,
                 'Astro::PAL' => 0,
-                'Time::Piece' => 1.02,
+                'Time::Piece' => 1.10,
                 'Astro::Telescope' => 0.71,
                 'DateTime' => 0.76,
                },

--- a/lib/Astro/Coords/Elements.pm
+++ b/lib/Astro/Coords/Elements.pm
@@ -159,7 +159,7 @@ sub new {
       # Split on decimal point
       my ($date, $frac) = split(/\./,$epoch,2);
       $frac = "0.". $frac; # preserve as decimal fraction
-      my $format = '%Y %B %d';
+      my $format = '%Y %b %d';
       #print "EPOCH : $epoch and $date and $frac\n";
       my $obj = Time::Piece->strptime($date, $format);
       my $tzoffset = $obj->tzoffset;

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,6 @@
 #!perl
 use strict;
-use Test::More tests => 102;
+use Test::More tests => 105;
 use Test::Number::Delta within => 1e-9;
 use Scalar::Util qw/ looks_like_number /;
 
@@ -313,6 +313,24 @@ if ($newbopp) {
 } else {
   ok(0, "Failed to create clone of elements object");
 }
+
+# Test parsing of date strings in for elements EPOCH.
+$c = new Astro::Coords(
+    elements => {EPOCH => '2013 Dec 04.0',
+                 ORBINC => 62.40397752235779 * &Astro::PAL::DD2R,
+                 ANODE => 295.65203155196 * &Astro::PAL::DD2R,
+                 PERIH => 345.5312406205832 * &Astro::PAL::DD2R,
+                 AORQ => 0.01245259242960607,
+                 E => 1.000201003833968,
+                 EPOCHPERIH => '2013 Nov 28.7786582736',
+                },
+    name => 'ISON');
+ok($c, 'Instantiate element object for ISON');
+my %c_elements = $c->elements();
+delta_ok($c_elements{'EPOCH'}, 56630.0,
+         'Compare parsed elements EPOCH');
+delta_ok($c_elements{'EPOCHPERIH'}, 56624.7786582736,
+         'Compare parsed elements EPOCHPERIH');
 
 # Make sure we can get a list of planet names
 my @planets = Astro::Coords::Planet->planets();


### PR DESCRIPTION
This would change the parsing of EPOCH strings (for elements coordinates) to require an abbreviated month name rather than a full name.  This is because if you follow the instructions in the documentation, which show a 3-letter month, parsing fails.  But it's possible someone relies on the old behavior?  It could perhaps try both instead?  Or use DateTime::Format::Strptime rather than Time::Piece -- its documentation says that %b and %B are equivalent and accept both forms?